### PR TITLE
Recursive signals causes crashes in moonunit - issue 11

### DIFF
--- a/src/plugins/c/c-run.c
+++ b/src/plugins/c/c-run.c
@@ -201,7 +201,7 @@ ctoken_result_fork(MuInterfaceToken* _token, const MuTestResult* summary)
 
     ctoken_free_fork(token);
     uipc_close(ipc_handle);
-    exit(0);
+    _exit(0);
 
     pthread_mutex_unlock(&token->lock);
 }


### PR DESCRIPTION
We can get into a recursive moonunit signal handling loop which will
eventually cause a crash.

This can happen if the test failed with a signal (i.e. times out or
aborts), the signal handler will catch it and call non-underscore
exit() which will call library destruction code paths. If the library
destruction code path happens to cause a signal (i.e. an abort) it
will call the signal handler again and potentially go through the
library destruction code path again.

This patch changes the exit command to _exit() so it does not call
the library destruction code paths.